### PR TITLE
Changed a typo (dependancies -> dependencies)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install
 npm start
 ```
 
-This will first install all dependancies, then run a development server complete with auto-reload.
+This will first install all dependencies, then run a development server complete with auto-reload.
 
 ## IDE setup
 


### PR DESCRIPTION
I changed a typo in the README.md file.

Word changed:
dependancies -> dependencies